### PR TITLE
[#10] SSU:Catch 공지사항 크롤링 코드 db ORM 작성.

### DIFF
--- a/ssu_catch.py
+++ b/ssu_catch.py
@@ -125,21 +125,6 @@ class Content:  # Crawling 결과를 담는 객체
                     self.img_link
                     )
 
-    def to_dict(self):
-        return {
-            "title": self.title,
-            "category": self.category.name if self.category else None,
-            "views": self.views,
-            "created_date": self.create_date.isoformat(),
-            "file_link": self.file_link,
-            "department": self.department,
-            "contents": self.contents,
-            "img_link": self.img_link
-        }
-
-    def to_json(self):
-        return json.dumps(self.to_dict())
-
 
 def ssu_catch_crawling(value):
     page = 1  # 1~

--- a/ssu_catch.py
+++ b/ssu_catch.py
@@ -3,8 +3,32 @@ import requests
 from bs4 import BeautifulSoup
 from enum import Enum, auto
 from datetime import date
+from sqlalchemy import create_engine
+from sqlalchemy import Column, Integer, CHAR, ARRAY, DateTime, TEXT
+from sqlalchemy.orm import sessionmaker, declarative_base
+import sqlalchemy
+import dev_db
 
 URL = "https://scatch.ssu.ac.kr/%ea%b3%b5%ec%a7%80%ec%82%ac%ed%95%ad"
+department_id_dict = {"교수학습혁신센터": 1, "총무감사팀": 2, "국제팀": 3, "기획팀": 4, "사회공헌팀": 5, "장학팀": 6, "학생서비스팀": 7, "정보화팀": 8,
+                      "교무팀": 9, "총무·인사팀": 10, "산학협력진흥팀": 11, "웹마스터": 12, "혁신공유대학 사업추진단": 13, "학사팀": 14, "창업지원단": 15,
+                      "공대 교학팀": 16, "진로취업센터": 17, "현장실습지원센터": 18, "교양교육연구센터": 19}
+# department id 어떻게 할지 생각해야함.
+Base = declarative_base()
+
+
+class NoticeDB(Base):
+    __tablename__ = "notice"
+    __table_args__ = {"schema": "notice"}
+    id = Column(Integer, primary_key=True)
+    title = Column(TEXT)
+    department_id = Column(Integer)
+    content = Column(TEXT)
+    category = Column(CHAR(32))  # 카테고리 Enum방식이면 db에 어떻게 저장할지 생각
+    image_url = Column(ARRAY(TEXT))
+    file_url = Column(ARRAY(TEXT))
+    created_at = Column(DateTime)
+    updated_at = Column(DateTime)
 
 
 class Category(Enum):
@@ -47,6 +71,7 @@ class Content:  # Crawling 결과를 담는 객체
         target = column.find('div')
         date_arr = [int(item) for item in target.text.strip().split(".")]
         self.create_date = date(date_arr[0], date_arr[1], date_arr[2])
+        self.updated_date = date(date_arr[0], date_arr[1], date_arr[2])
 
     def __init_contents(self, column):  # 본문 내용 크롤링
         self.img_link = []
@@ -72,17 +97,17 @@ class Content:  # Crawling 결과를 담는 객체
 
     def __init_category(self, column):  # 카테고리 크롤링
         category_dict = {
-            "학사": Category.school,
-            "장학": Category.scholarship,
-            "국제교류": Category.international,
-            "외국인유학생": Category.foreigner,
-            "채용": Category.employment,
-            "비교과·행사": Category.event,
-            "교원채용": Category.faculty_recruitment,
-            "봉사": Category.volunteer,
-            "교직": Category.teaching_profession,
-            "기타": Category.etc,
-            "코로나19관련소식": Category.covid19
+            "학사": 1,
+            "장학": 2,
+            "국제교류": 3,
+            "외국인유학생": 4,
+            "채용": 5,
+            "비교과·행사": 6,
+            "교원채용": 7,
+            "봉사": 8,
+            "교직": 9,
+            "기타": 10,
+            "코로나19관련소식": 11
         }
         target = column.find('span', class_='label')
         self.category = category_dict.get(target.text.strip())
@@ -92,7 +117,7 @@ class Content:  # Crawling 결과를 담는 객체
         self.title = target.text.strip()
 
     def __init_department(self, column):  # 등록 부서 크롤링
-        self.department = column.text.strip()
+        self.department = department_id_dict.get(column.text.strip())
 
     def __init_views(self, column):  # 조회수 크롤링
         self.views = int(column.text.strip())
@@ -144,8 +169,39 @@ def ssu_catch_crawling(value):
     for i in range(3):
         next(content_iterator)
     content_list = []
-    for (idx, item) in enumerate(content_iterator):
+    for (idx, item) in enumerate(content_iterator):  # 핵심 크롤링 부분
         if idx % 2 == 0:
-            content_list.append(Content(item.find('div')).to_dict())
+            content_list.append(Content(item.find('div')))
 
-    return json.dumps(content_list, indent=4)
+    db_url = sqlalchemy.engine.URL.create(  # db연결 url 생성
+        drivername="postgresql+psycopg2",
+        username=dev_db.dev_user_name,
+        password=dev_db.dev_db_pw,
+        host=dev_db.dev_host,
+        database=dev_db.dev_db_name
+    )
+
+    engine = create_engine(db_url)  # db 연결
+    session_maker = sessionmaker()
+    session_maker.configure(bind=engine)
+
+    with session_maker() as session:
+
+        for content in content_list:
+            if len(content.contents) >= 2048:
+                print("ERROR!!!!")  # content의 길이가 2048보다 클 경우가 있음.
+                print(len(content.contents))
+                print(content.contents)
+                break
+            session.add(NoticeDB(title=content.title,  # orm 객체 저장.
+                                 department_id=content.department,
+                                 content=content.contents,
+                                 image_url=content.img_link,
+                                 file_url=content.file_link,
+                                 created_at=content.create_date,
+                                 category=content.category,
+                                 updated_at=content.updated_date))
+        session.commit()
+
+
+ssu_catch_crawling(1)

--- a/ssu_catch.py
+++ b/ssu_catch.py
@@ -1,7 +1,6 @@
 import json
 import requests
 from bs4 import BeautifulSoup
-from enum import Enum, auto
 from datetime import date
 from sqlalchemy import create_engine
 from sqlalchemy import Column, Integer, CHAR, ARRAY, DateTime, TEXT
@@ -24,26 +23,11 @@ class NoticeDB(Base):
     title = Column(TEXT)
     department_id = Column(Integer)
     content = Column(TEXT)
-    category = Column(CHAR(32))  # 카테고리 Enum방식이면 db에 어떻게 저장할지 생각
+    category = Column(CHAR(32))
     image_url = Column(ARRAY(TEXT))
     file_url = Column(ARRAY(TEXT))
     created_at = Column(DateTime)
     updated_at = Column(DateTime)
-
-
-class Category(Enum):
-    # Category 용 Enum
-    school = auto()  # 학사
-    scholarship = auto()  # 장학
-    international = auto()  # 국제 교류
-    foreigner = auto()  # 외국인 유학생
-    employment = auto()  # 채용
-    event = auto()  # 비교과, 행사
-    faculty_recruitment = auto()  # 교원 채용
-    teaching_profession = auto()  # 교직
-    volunteer = auto()  # 봉사
-    etc = auto()  # 기타
-    covid19 = auto()  # 코로나 19 관련 소식
 
 
 class Content:  # Crawling 결과를 담는 객체
@@ -97,17 +81,17 @@ class Content:  # Crawling 결과를 담는 객체
 
     def __init_category(self, column):  # 카테고리 크롤링
         category_dict = {
-            "학사": 1,
-            "장학": 2,
-            "국제교류": 3,
-            "외국인유학생": 4,
-            "채용": 5,
-            "비교과·행사": 6,
-            "교원채용": 7,
-            "봉사": 8,
-            "교직": 9,
-            "기타": 10,
-            "코로나19관련소식": 11
+            "학사": "학사",
+            "장학": "장학",
+            "국제교류": "국제교류",
+            "외국인유학생": "외국인유학생",
+            "채용": "채용",
+            "비교과·행사": "비교과·행사",
+            "교원채용": "교원채용",
+            "봉사": "봉사",
+            "교직": "교직",
+            "기타": "기타",
+            "코로나19관련소식": "코로나19관련소식"
         }
         target = column.find('span', class_='label')
         self.category = category_dict.get(target.text.strip())
@@ -202,6 +186,3 @@ def ssu_catch_crawling(value):
                                  category=content.category,
                                  updated_at=content.updated_date))
         session.commit()
-
-
-ssu_catch_crawling(1)


### PR DESCRIPTION
## Issue

- Resolves #10 

## Description

- ssucatch 크롤링한 코드를 db에 commit하는 코드입니다.
- 얼추 완성하긴 했는데 몇가지 문제가 있습니다.
- 우선 content의 길이가 2048바이트보다 큰 경우가 있는 것으로 확인됩니다. 저장 가능한 용량을 더 늘려야 할 것 같습니다.
- 우선 8월 22일 기준 1페이지만 확인해 봤을 때 [2023학년도 2학기 숭실대학교 삼성반도체겸임교수 2차 채용 공고(모집단위 추가-SS9 산업정보시스템공학과)](https://scatch.ssu.ac.kr/%ea%b3%b5%ec%a7%80%ec%82%ac%ed%95%ad/?f&category&slug=68420&keyword) 가 2386바이트인 것으로 확인됩니다.
- 카테고리의 경우 Enum으로 파이썬 코드단에서 관리한다고 했는데, 아직 non null 32바이트 문자열로 되어있는 것으로 확인되어 일단 Enum을 다시 숫자로 변환해 넣었습니다.
- erdcloud에 학과라고 되어있는 department_id를 일단 부서라고 해석하고 처음에 문자열로 그냥 저장했었는데 이제보니 db에는 숫자가 들어가야 해서 임시로 19개의 부서는 일단 숫자로 변환하기는 했는데, 이거보다 더 많은 부서가 존재하고 더 추가되기도 쉬운 것으로 보입니다. 어떻게 처리해야 할지 논의가 필요할 것 같습니다. 제 생각에는 db에 부서정보를 따로 빼서 넣어 놓는 것이 이후 부서가 추가 되었을 때 수정할 필요가 없을 것 같습니다.

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
