### PR TITLE
[#24] 스마트캠퍼스 auth token 발급 로직 추가

### DIFF
--- a/auth_token.py
+++ b/auth_token.py
@@ -5,7 +5,10 @@ from Crypto.Cipher import PKCS1_v1_5
 from Crypto.PublicKey import RSA
 import base64
 
-def get_auth_token(sIdno, ssu_pwd):
+def get_auth_token(value):
+
+    sIdno = value['uid']
+    ssu_pwd = value['pw']
 
     common_header = {
         "referer": "https://smartid.ssu.ac.kr/Symtra_sso/smln.asp?apiReturnUrl=https%3A%2F%2Flms.ssu.ac.kr%2Fxn-sso%2Fgw-cb.php",
@@ -92,11 +95,3 @@ def decryption(res):
 
     return decrypt_pwd
 
-
-if __name__ == "__main__":
-    # 숭실대 유저의 학번과 비밀번호
-    sIdno = ""
-    ssu_pwd = ""
-
-    auth_token = get_auth_token(sIdno, ssu_pwd)
-    print(auth_token)

--- a/auth_token.py
+++ b/auth_token.py
@@ -1,0 +1,102 @@
+import requests
+from urllib import parse
+from bs4 import BeautifulSoup as bs
+from Crypto.Cipher import PKCS1_v1_5
+from Crypto.PublicKey import RSA
+import base64
+
+def get_auth_token(sIdno, ssu_pwd):
+
+    common_header = {
+        "referer": "https://smartid.ssu.ac.kr/Symtra_sso/smln.asp?apiReturnUrl=https%3A%2F%2Flms.ssu.ac.kr%2Fxn-sso%2Fgw-cb.php",
+        "user-agent": "",
+    }
+
+    session = requests.Session()
+
+    sToken_req_data = {
+        "in_tp_bit": "0",
+        "rqst_caus_cd": "03",
+        "userid": sIdno,
+        "pwd": ssu_pwd
+    }
+
+    # sToken 받아오기
+    sToken_url = "https://smartid.ssu.ac.kr/Symtra_sso/smln_pcs.asp"
+    res = session.post(sToken_url, headers = common_header, data = sToken_req_data)
+    login_cookies = requests.utils.dict_from_cookiejar(session.cookies)
+    sToken = login_cookies['sToken']
+
+    # 쿠키 정보들 받아오기
+    pass_token_url = f"https://lms.ssu.ac.kr/xn-sso/gw-cb.php?sToken={sToken}&sIdno={sIdno}"
+    res = session.get(pass_token_url, headers = common_header)
+    result = parse.urlparse(res.request.url)[4]
+
+    # 암호화 된 canvas pwd 발급받기
+    from_cc_url = f"https://canvas.ssu.ac.kr/learningx/login/from_cc?{result}"
+    res = session.get(from_cc_url, headers=common_header)
+
+    # pwd 파싱 및 복호화
+    decrypt_pwd = decryption(res)
+
+    canvas_data = {
+        'utf8': "%E2%9C%93",
+        'redirect_to_ssl': 1,
+        'pseudonym_session[unique_id]': sIdno,
+        'pseudonym_session[password]': decrypt_pwd,
+        'pseudonym_session[remember_me]': 0
+    }
+
+    canvas_header = {
+        "referer": from_cc_url,
+        "user-agent": "",
+    }
+
+    # 복호화한 패스워드로 스마트캠퍼스 로그인하기
+    canvas_url = f"https://canvas.ssu.ac.kr/login/canvas"
+    res = session.post(canvas_url, headers = canvas_header, data = canvas_data)
+
+
+    auth_token_header = {
+        "referer": "https://lms.ssu.ac.kr/",
+        "user-agent": "",
+    }
+
+    # 유저 정보 조회를 위한 토큰 발급
+    token_url = f"https://canvas.ssu.ac.kr/learningx/dashboard?user_login={sIdno}&locale=ko"
+    res = session.get(token_url, headers = auth_token_header)
+
+    auth_token = res.headers['Set-Cookie'].split(";")[0][13:]
+    return auth_token
+
+
+def decryption(res):
+    soup = bs(res.text, 'lxml')
+
+    # key와 암호화 된 pwd 파싱하기
+    elements = soup.select('script')
+    element = list(elements[2].text.lstrip().split("\""))
+    cryt = element[1]
+    private = element[3].replace("-----BEGIN RSA PRIVATE KEY-----", "").replace("-----END RSA PRIVATE KEY-----", "")
+
+    pem_prefix = '-----BEGIN RSA PRIVATE KEY-----\n'
+    pem_suffix = '\n-----END RSA PRIVATE KEY-----'
+    private = '{}{}{}'.format(pem_prefix, private, pem_suffix)
+
+    # 발급받은 pw 복호화하기
+    rsa_key = RSA.importKey(private)
+    cipher = PKCS1_v1_5.new(rsa_key)
+
+    raw_cyp = base64.b64decode(cryt)
+    decrypt_pwd = cipher.decrypt(raw_cyp, None).decode()
+
+    return decrypt_pwd
+
+
+if __name__ == "__main__":
+    # 숭실대 유저의 학번과 비밀번호
+    sIdno = ""
+    ssu_pwd = ""
+
+    auth_token = get_auth_token(sIdno, ssu_pwd)
+    print(auth_token)

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -4,6 +4,7 @@ from smart_campus import smart_campus
 from departments import departments_crawling
 from fun_system import fus_system_crawling
 from ssu_catch import ssu_catch_crawling
+from auth_token import get_auth_token
 
 def lambda_handler(event, context):
     body = json.loads(event['body'])
@@ -18,6 +19,8 @@ def lambda_handler(event, context):
         result = fus_system_crawling(value)
     elif function_name == 'ssu_catch':
         result = ssu_catch_crawling(value)
+    elif function_name == 'auth_token':
+        result = get_auth_token(value)
     else:
         result = "Function not found"
     


### PR DESCRIPTION
## Issue

- Resolves #24 

## Description

- 스마트캠퍼스에서 수강 과목 조회를 하는데 필요한 Bearer 토큰을 발급하는 로직을 추가했습니다. 아직 람다와 연결하진 않았고, 해당 로직으로 발급한 토큰이 스마트캠퍼스 크롤링에서 올바르게 작동하는게 확인되면 람다와 연결하도록 하겠습니다.
 
## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
